### PR TITLE
Sync with develop branch

### DIFF
--- a/src/xr_parser.py
+++ b/src/xr_parser.py
@@ -1117,12 +1117,8 @@ class DefaultDatasetParser():
 
         # normal case: T axis has been parsed into cftime Datetime objects, and
         # the following works successfully.
-        cftime_cal = getattr(t_coord.values[0], 'calendar', None)
-        # look in other places if that failed:
-        if not cftime_cal:
-            self.log.warning("cftime calendar info parse failed on '%s'.",
-                t_coord.name)
-            cftime_cal = _get_calendar(t_coord.encoding)
+        cftime_cal = None
+        cftime_cal = _get_calendar(t_coord.encoding)
         if not cftime_cal:
             cftime_cal = _get_calendar(t_coord.attrs)
         if not cftime_cal:


### PR DESCRIPTION
* Change cf_time calendar logic

* remove check for cftime calendar in tcoord.values

The cftime calendar attribute is most likely present in other t_coord and ds features that are checked, so remove
unnecessary assumption of calendar att in t_coord.values[0]

**Description**
Include a summary of the change, and link the associated issue (if applicable).  
List any dependencies that are required for this change, including libraries and variables,  
and their metadata (units, frequencies, etc...). Be sure to separate PRs and issues for new PODs and PODs currently under development.

Associated issue # (replace this phrase and parentheses with the issue number)  

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes in enough detail that  
someone can reproduce them. Include any relevant details for your test configuration  
such as the Python version, package versions, expected POD wallclock time, and the   
operating system(s) you ran your tests on.

**Checklist:**
- [ ] I have reviewed my own code to ensure that if follows the [POD development guidelines](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/dev_guidelines.html)
- [ ] My branch is up-to-date with the NOAA-GFDL develop branch, and all merge conflicts are resolved
- [ ] The script are written in Python 3.6 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] If applicable, I've added a .yml file to src/conda, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] The repository contains no extra test scripts or data files
