### PR TITLE
Fix Explicit_file CLI definition

### DIFF
--- a/doc/sphinx/ref_data_sources.rst
+++ b/doc/sphinx/ref_data_sources.rst
@@ -47,7 +47,7 @@ When using this data source, ``-c``/``--convention`` should be set to the conven
 Explicit file data source
 +++++++++++++++++++++++++
 
-Selected via ``--data-manager="ExplicitFile"``.
+Selected via ``--data-manager="Explicit_file"``.
 
 This data source lets the user explicitly assign model data files to each variable requested by a POD using standard shell glob syntax, without needing to move or symlink them to a directory hierarchy (as is needed for, e.g., the :ref:`ref-data-source-localfile`). Files must be on a locally mounted filesystem, and satisfy the requirements in :doc:`ref_data` (with the exception of metadata).
 


### PR DESCRIPTION
**Description**
Include a summary of the change, and link the associated issue (if applicable).  
List any dependencies that are required for this change, including libraries and variables,  
and their metadata (units, frequencies, etc...). Be sure to separate PRs and issues for new PODs and PODs currently under development.

Associated issue # (replace this phrase and parentheses with the issue number)  

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes in enough detail that  
someone can reproduce them. Include any relevant details for your test configuration  
such as the Python version, package versions, expected POD wallclock time, and the   
operating system(s) you ran your tests on.

**Checklist:**
- [ ] I have reviewed my own code to ensure that if follows the [POD development guidelines](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/dev_guidelines.html)
- [ ] My branch is up-to-date with the NOAA-GFDL develop branch, and all merge conflicts are resolved
- [ ] The script are written in Python 3.6 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] If applicable, I've added a .yml file to src/conda, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] The repository contains no extra test scripts or data files
