### PR TITLE
change required python version to 3.7 in PR template (#353)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,7 +14,7 @@ operating system(s) you ran your tests on.
 **Checklist:**
 - [ ] I have reviewed my own code to ensure that if follows the [POD development guidelines](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/dev_guidelines.html)
 - [ ] My branch is up-to-date with the NOAA-GFDL develop branch, and all merge conflicts are resolved
-- [ ] The script are written in Python 3.6 or above (preferred; required if funded by a CPO grant), NCL, or R
+- [ ] The scripts are written in Python 3.7 or above (preferred; required if funded by a CPO grant), NCL, or R
 - [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
 - [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
 - [ ] If applicable, I've added a .yml file to src/conda, and my environment builds with `conda_env_setup.sh` 

--- a/doc/sphinx/dev_start.rst
+++ b/doc/sphinx/dev_start.rst
@@ -32,7 +32,7 @@ Installing dependencies via conda
 Regardless of development language, we strongly recommend that developers use conda to manage their language and library versions. Note that Conda is not Python-specific, but allows coexisting versioned environments of most scripting languages, including, `R <https://anaconda.org/conda-forge/r-base>`__, `NCL <https://anaconda.org/conda-forge/ncl>`__, `Ruby <https://anaconda.org/conda-forge/ruby>`__, `PyFerret <https://anaconda.org/conda-forge/pyferret>`__, and more.
 
 
-We recommend that new PODs be written in Python 3. We provide a developer version of the python3_base environment (described below) that includes Jupyter and other developer-specific tools. This is not installed by default, and must be requested by passing the ``-all-dev`` flag to the conda setup script:
+Python-based PODs should be written in Python 3.7 or newer. We provide a developer version of the python3_base environment (described below) that includes Jupyter and other developer-specific tools. This is not installed by default, and must be requested by passing the ``-all-dev`` flag to the conda setup script:
 
 .. code-block:: console
 


### PR DESCRIPTION
* change required python version to 3.7 in PR template

* Update dev_start.rst

* Update PULL_REQUEST_TEMPLATE.md

**Description**
Include a summary of the change, and link the associated issue (if applicable).  
List any dependencies that are required for this change, including libraries and variables,  
and their metadata (units, frequencies, etc...). Be sure to separate PRs and issues for new PODs and PODs currently under development.

Associated issue # (replace this phrase and parentheses with the issue number)  

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes in enough detail that  
someone can reproduce them. Include any relevant details for your test configuration  
such as the Python version, package versions, expected POD wallclock time, and the   
operating system(s) you ran your tests on.

**Checklist:**
- [ ] I have reviewed my own code to ensure that if follows the [POD development guidelines](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/dev_guidelines.html)
- [ ] My branch is up-to-date with the NOAA-GFDL develop branch, and all merge conflicts are resolved
- [ ] The scripts are written in Python 3.7 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] If applicable, I've added a .yml file to src/conda, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] The repository contains no extra test scripts or data files
